### PR TITLE
Исправлены предупреждения tflint и checkov

### DIFF
--- a/dz_terraform/dz_05/main.tf
+++ b/dz_terraform/dz_05/main.tf
@@ -29,7 +29,7 @@ module "vpc_prod_module" {
 
 
 module "marketing-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=09144db7f136b793064f1ac593fe2ac6921932f0"  # Указываем хэш коммита для фиксации версии модуля
   env_name       = "prod" 
   network_id     = module.vpc_prod_module.subnet_prod_a.network_id  #network_id_value
   subnet_zones   = [module.vpc_prod_module.subnet_prod_a.zone]  #subnet_zone_value
@@ -37,7 +37,8 @@ module "marketing-vm" {
   instance_name  = "vm-marketing"
   instance_count = 1
   image_family   = "ubuntu-2004-lts"
-  public_ip      = true
+  security_group_ids = [module.vpc_prod_module.vpc_security_group_prod.id]
+  public_ip      = false        #true
   depends_on = [
     module.vpc_prod_module
   ]
@@ -47,14 +48,14 @@ module "marketing-vm" {
      }
 
   metadata = {
-    user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
+    user-data          = data.template_file.cloudinit.rendered 
     serial-port-enable = 1
   }
 
 }
 
 module "analytics-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=09144db7f136b793064f1ac593fe2ac6921932f0"         # Указываем хэш коммита для фиксации версии модуля
   env_name       = "stage"
   network_id     = module.vpc_prod_module.subnet_prod_a.network_id
   subnet_zones   = [module.vpc_prod_module.subnet_prod_a.zone]
@@ -62,7 +63,8 @@ module "analytics-vm" {
   instance_name  = "vm-analytics"
   instance_count = 1
   image_family   = "ubuntu-2004-lts"
-  public_ip      = true
+  public_ip      = false         #true
+  security_group_ids = [module.vpc_prod_module.vpc_security_group_prod.id]
   depends_on = [
     module.vpc_prod_module
   ]

--- a/dz_terraform/dz_05/providers.tf
+++ b/dz_terraform/dz_05/providers.tf
@@ -1,7 +1,12 @@
 terraform {
   required_providers {
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2.0"                  #Актуальная версия провайдера  hashicorp/template
+    }
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "0.146.0"                   #Актуальная версия провайдера yandex-cloud
     }
   }
   required_version = "~>1.8.4"

--- a/dz_terraform/dz_05/vpc_prod_module/main.tf
+++ b/dz_terraform/dz_05/vpc_prod_module/main.tf
@@ -19,3 +19,22 @@ resource "yandex_vpc_subnet" "prod_a" {
   network_id     = yandex_vpc_network.prod.id
   v4_cidr_blocks = var.cidr_blocks
 }
+
+resource "yandex_vpc_security_group" "prod" {
+  name        = "vms-security-group"
+  description = "security group for my vms"
+  network_id  = yandex_vpc_network.prod.id
+
+  ingress {
+    protocol       = "TCP"
+    description    = "Allow SSH"
+    port          = 22
+    v4_cidr_blocks = var.cidr_blocks #
+  }
+
+  egress {
+    protocol       = "ANY"
+    description    = "Allow all outgoing traffic"
+    v4_cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/dz_terraform/dz_05/vpc_prod_module/outputs.tf
+++ b/dz_terraform/dz_05/vpc_prod_module/outputs.tf
@@ -13,6 +13,10 @@
 #}
 
 output "subnet_prod_a" {
-  description = "ID подсети"
+  description = "subnet info"
   value = yandex_vpc_subnet.prod_a
+}
+output "vpc_security_group_prod" {
+  description = "securrity group prod info"
+  value = yandex_vpc_security_group.prod
 }


### PR DESCRIPTION
```
aleksandrov_sp@aleksandrov-sp-test:~/netology/netology_homework/dz_terraform/dz_05$ git branch -a 
  main
* terraform-hotfix
  remotes/origin/HEAD -> origin/main
  remotes/origin/main
  remotes/origin/terraform-hotfix
aleksandrov_sp@aleksandrov-sp-test:~/netology/netology_homework/dz_terraform/dz_05$ tflint
aleksandrov_sp@aleksandrov-sp-test:~/netology/netology_homework/dz_terraform/dz_05$ docker run --rm --tty --volume $(pwd):/tf --workdir /tf bridgecrew/checkov --download-external-modules true --directory /tf
2025-08-02 07:35:27,041 [MainThread  ] [WARNI]  Failed to get the checkov mappings and guidelines from https://api0.prismacloud.io/bridgecrew/api/v2/guidelines. Skips using BC_* IDs will not work.
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/urllib3/connection.py", line 174, in _new_conn
    conn = connection.create_connection(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/util/connection.py", line 95, in create_connection
    raise err
  File "/usr/local/lib/python3.11/site-packages/urllib3/util/connection.py", line 85, in create_connection
    sock.connect(sa)
TimeoutError: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 716, in urlopen
    httplib_response = self._make_request(
                       ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 404, in _make_request
    self._validate_conn(conn)
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 1061, in _validate_conn
    conn.connect()
  File "/usr/local/lib/python3.11/site-packages/urllib3/connection.py", line 363, in connect
    self.sock = conn = self._new_conn()
                       ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connection.py", line 179, in _new_conn
    raise ConnectTimeoutError(
urllib3.exceptions.ConnectTimeoutError: (<urllib3.connection.HTTPSConnection object at 0x784f72925fd0>, 'Connection to api0.prismacloud.io timed out. (connect timeout=3.1)')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/checkov/common/bridgecrew/platform_integration.py", line 1273, in get_public_run_config
    request = self.http.request("GET", self.guidelines_api_url, headers=headers)  # type:ignore[no-untyped-call]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/request.py", line 77, in request
    return self.request_encode_url(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/request.py", line 99, in request_encode_url
    return self.urlopen(method, url, **extra_kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/poolmanager.py", line 376, in urlopen
    response = conn.urlopen(method, u.request_uri, **kw)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 830, in urlopen
    return self.urlopen(
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 830, in urlopen
    return self.urlopen(
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 830, in urlopen
    return self.urlopen(
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 802, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/util/retry.py", line 594, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='api0.prismacloud.io', port=443): Max retries exceeded with url: /bridgecrew/api/v2/guidelines (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x784f72925fd0>, 'Connection to api0.prismacloud.io timed out. (connect timeout=3.1)'))

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By Prisma Cloud | version: 3.2.457 

terraform scan results:

Passed checks: 11, Failed checks: 0, Skipped checks: 0

Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/09144db7f136b793064f1ac593fe2ac6921932f0/main.tf:24-73
        Calling File: /main.tf:57-81
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        PASSED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/09144db7f136b793064f1ac593fe2ac6921932f0/main.tf:24-73
        Calling File: /main.tf:57-81
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        PASSED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/09144db7f136b793064f1ac593fe2ac6921932f0/main.tf:24-73
        Calling File: /main.tf:57-81
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/09144db7f136b793064f1ac593fe2ac6921932f0/main.tf:24-73
        Calling File: /main.tf:31-55
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        PASSED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/09144db7f136b793064f1ac593fe2ac6921932f0/main.tf:24-73
        Calling File: /main.tf:31-55
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        PASSED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/09144db7f136b793064f1ac593fe2ac6921932f0/main.tf:24-73
        Calling File: /main.tf:31-55
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: marketing-vm
        File: /main.tf:31-55
Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
        PASSED for resource: marketing-vm
        File: /main.tf:31-55
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: analytics-vm
        File: /main.tf:57-81
Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
        PASSED for resource: analytics-vm
        File: /main.tf:57-81
Check: CKV_YC_19: "Ensure security group does not contain allow-all rules."
        PASSED for resource: module.vpc_prod_module.yandex_vpc_security_group.prod
        File: /vpc_prod_module/main.tf:23-40
        Calling File: /main.tf:21-28
```
```
aleksandrov_sp@aleksandrov-sp-test:~/netology/netology_homework/dz_terraform/dz_05$ terraform plan
data.template_file.cloudinit: Reading...
data.template_file.cloudinit: Read complete after 0s [id=9638e96e08caf433161906809f196c3f2efc4fca46c75198a83b62af25660bfe]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # module.analytics-vm.data.yandex_compute_image.my_image will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "yandex_compute_image" "my_image" {
      + created_at          = (known after apply)
      + description         = (known after apply)
      + family              = "ubuntu-2004-lts"
      + folder_id           = (known after apply)
      + hardware_generation = (known after apply)
      + id                  = (known after apply)
      + image_id            = (known after apply)
      + kms_key_id          = (known after apply)
      + labels              = (known after apply)
      + min_disk_size       = (known after apply)
      + name                = (known after apply)
      + os_type             = (known after apply)
      + pooled              = (known after apply)
      + product_ids         = (known after apply)
      + size                = (known after apply)
      + status              = (known after apply)
    }

  # module.analytics-vm.yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform yyy managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hardware_generation       = (known after apply)
      + hostname                  = "stage-vm-analytics-0"
      + id                        = (known after apply)
      + labels                    = {
          + "owner"   = "i.ivanov"
          + "project" = "analytics"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
                    ssh_authorized_keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOoev5jqN92osASI07AwpFhwWBrJtXhNDzxTMX6fNu07 aleksandrov_sp@aleksandrov-sp-test
                      
                package_update: true
                package_upgrade: false
                packages:
                  - vim
                  - nginx
            EOT
        }
      + name                      = "stage-vm-analytics-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = (known after apply)
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = false
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

  # module.marketing-vm.data.yandex_compute_image.my_image will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "yandex_compute_image" "my_image" {
      + created_at          = (known after apply)
      + description         = (known after apply)
      + family              = "ubuntu-2004-lts"
      + folder_id           = (known after apply)
      + hardware_generation = (known after apply)
      + id                  = (known after apply)
      + image_id            = (known after apply)
      + kms_key_id          = (known after apply)
      + labels              = (known after apply)
      + min_disk_size       = (known after apply)
      + name                = (known after apply)
      + os_type             = (known after apply)
      + pooled              = (known after apply)
      + product_ids         = (known after apply)
      + size                = (known after apply)
      + status              = (known after apply)
    }

  # module.marketing-vm.yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform yyy managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hardware_generation       = (known after apply)
      + hostname                  = "prod-vm-marketing-0"
      + id                        = (known after apply)
      + labels                    = {
          + "owner"   = "i.ivanov"
          + "project" = "marketing"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
                    ssh_authorized_keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOoev5jqN92osASI07AwpFhwWBrJtXhNDzxTMX6fNu07 aleksandrov_sp@aleksandrov-sp-test
                      
                package_update: true
                package_upgrade: false
                packages:
                  - vim
                  - nginx
            EOT
        }
      + name                      = "prod-vm-marketing-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = (known after apply)
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = false
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

  # module.vpc_prod_module.yandex_vpc_network.prod will be created
  + resource "yandex_vpc_network" "prod" {
      + created_at                = (known after apply)
      + default_security_group_id = (known after apply)
      + folder_id                 = (known after apply)
      + id                        = (known after apply)
      + labels                    = (known after apply)
      + name                      = "prod"
      + subnet_ids                = (known after apply)
    }

  # module.vpc_prod_module.yandex_vpc_security_group.prod will be created
  + resource "yandex_vpc_security_group" "prod" {
      + created_at  = (known after apply)
      + description = "security group for my vms"
      + folder_id   = (known after apply)
      + id          = (known after apply)
      + labels      = (known after apply)
      + name        = "vms-security-group"
      + network_id  = (known after apply)
      + status      = (known after apply)

      + egress {
          + description       = "Allow all outgoing traffic"
          + from_port         = -1
          + id                = (known after apply)
          + labels            = (known after apply)
          + port              = -1
          + protocol          = "ANY"
          + to_port           = -1
          + v4_cidr_blocks    = [
              + "0.0.0.0/0",
            ]
          + v6_cidr_blocks    = []
            # (2 unchanged attributes hidden)
        }

      + ingress {
          + description       = "Allow SSH"
          + from_port         = -1
          + id                = (known after apply)
          + labels            = (known after apply)
          + port              = 22
          + protocol          = "TCP"
          + to_port           = -1
          + v4_cidr_blocks    = [
              + "10.0.1.0/24",
            ]
          + v6_cidr_blocks    = []
            # (2 unchanged attributes hidden)
        }
    }

  # module.vpc_prod_module.yandex_vpc_subnet.prod_a will be created
  + resource "yandex_vpc_subnet" "prod_a" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "prod-ru-central1-a"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.1.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + out = [
      + (known after apply),
      + (known after apply),
    ]

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

<img width="1480" height="843" alt="terraform-05-03-1" src="https://github.com/user-attachments/assets/f1429288-9a98-4d2c-903b-dc37af83e5e3" />
<img width="1183" height="924" alt="terraform-05-03-2" src="https://github.com/user-attachments/assets/6b773974-603f-46ff-8efc-bcb04893e885" />
